### PR TITLE
Bump minimum CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(
   vrt


### PR DESCRIPTION
This suppresses warnings in newer versions of cmake.